### PR TITLE
Add krb as dependency so it isn't found in the BUILD_PREFIX

### DIFF
--- a/.ci_support/linux_64_openssl1.1.1.yaml
+++ b/.ci_support/linux_64_openssl1.1.1.yaml
@@ -14,9 +14,13 @@ cxx_compiler_version:
 - '10'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
+krb5:
+- '1.19'
 openssl:
 - 1.1.1
 pin_run_as_build:
+  krb5:
+    max_pin: x.x
   zlib:
     max_pin: x.x
 target_platform:

--- a/.ci_support/linux_64_openssl3.yaml
+++ b/.ci_support/linux_64_openssl3.yaml
@@ -14,9 +14,13 @@ cxx_compiler_version:
 - '10'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
+krb5:
+- '1.19'
 openssl:
 - '3'
 pin_run_as_build:
+  krb5:
+    max_pin: x.x
   zlib:
     max_pin: x.x
 target_platform:

--- a/.ci_support/linux_aarch64_openssl1.1.1.yaml
+++ b/.ci_support/linux_aarch64_openssl1.1.1.yaml
@@ -18,9 +18,13 @@ cxx_compiler_version:
 - '10'
 docker_image:
 - quay.io/condaforge/linux-anvil-aarch64
+krb5:
+- '1.19'
 openssl:
 - 1.1.1
 pin_run_as_build:
+  krb5:
+    max_pin: x.x
   zlib:
     max_pin: x.x
 target_platform:

--- a/.ci_support/linux_aarch64_openssl3.yaml
+++ b/.ci_support/linux_aarch64_openssl3.yaml
@@ -18,9 +18,13 @@ cxx_compiler_version:
 - '10'
 docker_image:
 - quay.io/condaforge/linux-anvil-aarch64
+krb5:
+- '1.19'
 openssl:
 - '3'
 pin_run_as_build:
+  krb5:
+    max_pin: x.x
   zlib:
     max_pin: x.x
 target_platform:

--- a/.ci_support/linux_ppc64le_openssl1.1.1.yaml
+++ b/.ci_support/linux_ppc64le_openssl1.1.1.yaml
@@ -14,9 +14,13 @@ cxx_compiler_version:
 - '10'
 docker_image:
 - quay.io/condaforge/linux-anvil-ppc64le
+krb5:
+- '1.19'
 openssl:
 - 1.1.1
 pin_run_as_build:
+  krb5:
+    max_pin: x.x
   zlib:
     max_pin: x.x
 target_platform:

--- a/.ci_support/linux_ppc64le_openssl3.yaml
+++ b/.ci_support/linux_ppc64le_openssl3.yaml
@@ -14,9 +14,13 @@ cxx_compiler_version:
 - '10'
 docker_image:
 - quay.io/condaforge/linux-anvil-ppc64le
+krb5:
+- '1.19'
 openssl:
 - '3'
 pin_run_as_build:
+  krb5:
+    max_pin: x.x
   zlib:
     max_pin: x.x
 target_platform:

--- a/.ci_support/osx_64_openssl1.1.1.yaml
+++ b/.ci_support/osx_64_openssl1.1.1.yaml
@@ -12,11 +12,15 @@ cxx_compiler:
 - clangxx
 cxx_compiler_version:
 - '14'
+krb5:
+- '1.19'
 macos_machine:
 - x86_64-apple-darwin13.4.0
 openssl:
 - 1.1.1
 pin_run_as_build:
+  krb5:
+    max_pin: x.x
   zlib:
     max_pin: x.x
 target_platform:

--- a/.ci_support/osx_64_openssl3.yaml
+++ b/.ci_support/osx_64_openssl3.yaml
@@ -12,11 +12,15 @@ cxx_compiler:
 - clangxx
 cxx_compiler_version:
 - '14'
+krb5:
+- '1.19'
 macos_machine:
 - x86_64-apple-darwin13.4.0
 openssl:
 - '3'
 pin_run_as_build:
+  krb5:
+    max_pin: x.x
   zlib:
     max_pin: x.x
 target_platform:

--- a/.ci_support/osx_arm64_openssl1.1.1.yaml
+++ b/.ci_support/osx_arm64_openssl1.1.1.yaml
@@ -12,11 +12,15 @@ cxx_compiler:
 - clangxx
 cxx_compiler_version:
 - '14'
+krb5:
+- '1.19'
 macos_machine:
 - arm64-apple-darwin20.0.0
 openssl:
 - 1.1.1
 pin_run_as_build:
+  krb5:
+    max_pin: x.x
   zlib:
     max_pin: x.x
 target_platform:

--- a/.ci_support/osx_arm64_openssl3.yaml
+++ b/.ci_support/osx_arm64_openssl3.yaml
@@ -12,11 +12,15 @@ cxx_compiler:
 - clangxx
 cxx_compiler_version:
 - '14'
+krb5:
+- '1.19'
 macos_machine:
 - arm64-apple-darwin20.0.0
 openssl:
 - '3'
 pin_run_as_build:
+  krb5:
+    max_pin: x.x
   zlib:
     max_pin: x.x
 target_platform:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 07392c54ab61476288d1c1f0a7c557b50211797ad00c34c3af2bbc4dbc4bd97d
 
 build:
-  number: 1
+  number: 2
   skip: true  # [not unix]
   run_exports:
     # We pin to a minor version due to an incompatibility 
@@ -27,6 +27,7 @@ requirements:
   host:
     - openssl
     - zlib
+    - krb5
 
 test:
   commands:


### PR DESCRIPTION
Closes: https://github.com/conda-forge/libssh-feedstock/issues/16

I built this locally and it seems to help.


Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
